### PR TITLE
Fixing URL datatype logic error

### DIFF
--- a/qbclient/model_datatype.go
+++ b/qbclient/model_datatype.go
@@ -448,7 +448,7 @@ func NewURLValue(val *url.URL) *Value {
 // NewURLValueFromString returns a new Value of the FieldURL type.
 func NewURLValueFromString(val string) (v *Value, err error) {
 	var u *url.URL
-	if u, err = url.Parse(val); err != nil {
+	if u, err = url.Parse(val); err == nil {
 		v = &Value{URL: u, QuickBaseType: FieldURL}
 	}
 	return


### PR DESCRIPTION
URL datatypes were looking for an error from parsing in order to convert meaning only an error state would cause a URL conversion (needed flipped to absence of an error).